### PR TITLE
PUELIA_SERVE_FROM_CACHE true should be false

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Note: The ARC library harcodes the limit on the execution time of a function cal
 
 to
 
-  define('PUELIA_SERVE_FROM_CACHE', true);
+  define('PUELIA_SERVE_FROM_CACHE', false);
 
 2. yum install php-pecl-memcache
 


### PR DESCRIPTION
define('PUELIA_SERVE_FROM_CACHE', true) is repeated twice in the readme when it should probably be telling you to set it to false according to the default value in https://github.com/openphacts/OPS_LinkedDataApi/blob/1.4.0/deployment.settings.php
